### PR TITLE
Depend on pytest >= 7.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
   run:
     - python >=3.7
-    - pytest >=3.0.0,<8.0.0
+    - pytest >=7.0.0,<8.0.0
 
 test:
   imports:


### PR DESCRIPTION
In https://github.com/pytest-dev/pytest-metadata/pull/65/files#diff-214577d52fdc7b04dd2fc87cac8fc070150a15c4dd22baf388ae00baba3c074dR34, pytest_metadata started using pytest's stashKey attribute which was introduced in 7.0.0 (PR here: https://github.com/pytest-dev/pytest/commit/5470d33e82aaa203108423f5d3d9c7228c83090b#diff-58f237ab3ea2db160ae3078fbdbd50151b00b4492804449d78879bd372624bc9R16) The PR updates the dependencies pytest-metadata has on pytest.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
